### PR TITLE
Template for the Overview of Reductions

### DIFF
--- a/Karp21/All_Reductions.thy
+++ b/Karp21/All_Reductions.thy
@@ -1,11 +1,43 @@
 theory All_Reductions
   imports
-    Three_Sat_To_Set_Cover
-    "CNF_SAT_To_Clique/CNF_SAT_To_Clique"
-    "HC_To_UHC/HC_To_UHC"
-    "VC_Set_To_VC_List/VC_Set_To_VC_List"
-    "VC_To_HC/VC_To_HC"
-    "VC_To_FNS/VC_To_FNS"
+    "Three_DM_To_X3C"
+    "CNF_SAT_To_Clique"
+    "HC_To_UHC"
+    "SAT_To_XC"
+    "TC_To_ChrN"
+    "VC_Set_To_VC_List"
+    "VC_To_FAS"
+    "VC_To_FNS"
+    "VC_To_HC"
+    "X3C_To_ST"
+    "Exact_Cover_To_3D_Matching"
+    "XC_To_EHS"
+    "XC_To_SS"
+    "XC_To_ST_Karp72"
 begin
+
+section \<open>Overview of reductions\<close>
+text \<open>
+  \<^item> SAT
+    \<^item> Clique @{thm is_reduction_cnf_sat_to_clique}
+      \<^item> Set Packing
+      \<^item> Node Cover
+        \<^item> Feedback Node Set
+        \<^item> Feedback Arc Set
+        \<^item> Directed Hamilton Circuit
+          \<^item> Undirected Hamilton Circuit
+        \<^item> Set Covering
+    \<^item> 0-1 Integer Programming
+    \<^item> 3-SAT
+      \<^item> Chromatic Number
+      \<^item> Exact Cover
+        \<^item> 3-Dimensional Matching
+        \<^item> Hitting Set
+        \<^item> Steiner Tree
+      \<^item> Knapsack
+        \<^item> Sequencing
+        \<^item> Partition
+          \<^item> Max Cut
+\<close>
 
 end

--- a/Karp21/ROOT
+++ b/Karp21/ROOT
@@ -1,0 +1,23 @@
+session Karp21 = Poly_Reductions_Lib +
+  sessions
+    NREST
+  directories
+    "3DM_To_X3C"
+    "CNF_SAT_To_Clique"
+    "CNF_SAT_To_TC"
+    "HC_To_UHC"
+    "SAT_To_XC"
+    "SS_To_JS"
+    "TC_To_ChrN"
+    "VC_Set_To_VC_List"
+    "VC_To_FAS"
+    "VC_To_FNS"
+    "VC_To_HC"
+    "weight_problems"
+    "X3C_To_ST"
+    "XC_To_3DM"
+    "XC_To_EHS"
+    "XC_To_SS"
+    "XC_To_ST"
+  theories
+    All_Reductions

--- a/Karp21/SAT_To_XC/SAT_To_XC_poly.thy
+++ b/Karp21/SAT_To_XC/SAT_To_XC_poly.thy
@@ -1,5 +1,5 @@
 theory SAT_To_XC_poly
-  imports  "../TSTSC_Poly" "../../Lib/Auxiliaries/Set_Auxiliaries" SAT_To_XC
+  imports  "../TSTSC_Poly" "Poly_Reductions_Lib.Set_Auxiliaries" SAT_To_XC
 begin
 
 section "the reduction from sat to xc is polynomial"

--- a/Karp21/SAT_To_XC/XC_Definition.thy
+++ b/Karp21/SAT_To_XC/XC_Definition.thy
@@ -1,7 +1,7 @@
 theory XC_Definition
   imports "../Polynomial_Reductions"
           "HOL-Library.Disjoint_Sets"
-          "../../Lib/SAT_Definition"
+          "Poly_Reductions_Lib.SAT_Definition"
 begin
 
 subsection "Exact cover definitions"

--- a/Karp21/VC_To_FAS/VC_To_Fas.thy
+++ b/Karp21/VC_To_FAS/VC_To_Fas.thy
@@ -1,9 +1,9 @@
-theory VC_To_Fas                                                          
+theory VC_To_FAS                                                         
   imports  "../Reductions"
            FAS_Definition
            "../Three_Sat_To_Set_Cover" (* vertex cover is defined here *)
            NTIMES (* ntimes *)
-           "../../Lib/Auxiliaries/Set_Auxiliaries" (* card_Collect_mem *)
+           "Poly_Reductions_Lib.Set_Auxiliaries" (* card_Collect_mem *)
 begin
 
 (* helper lemmas *)   

--- a/Karp21/X3C_To_ST/X3C_To_ST.thy
+++ b/Karp21/X3C_To_ST/X3C_To_ST.thy
@@ -1,8 +1,8 @@
 theory X3C_To_ST
-  imports ST_Definition "../Reductions" 
-          "../../Lib/Auxiliaries/discriminated_Union"
-          "../3DM_To_X3C/X3C_Definition" 
-          "../../Lib/Auxiliaries/Set_Auxiliaries" (* card_Collect_mem *)
+  imports ST_Definition "Reductions" 
+          "Poly_Reductions_Lib.Discriminated_Union"
+          "X3C_Definition" 
+          "Poly_Reductions_Lib.Set_Auxiliaries" (* card_Collect_mem *)
 begin
 
 (* reduction *)

--- a/Karp21/XC_To_3DM/Exact_Cover_to_3D_Matching.thy
+++ b/Karp21/XC_To_3DM/Exact_Cover_to_3D_Matching.thy
@@ -1,12 +1,10 @@
-theory Exact_Cover_to_3D_Matching
+theory Exact_Cover_To_3D_Matching
   imports Main 
           "HOL-Library.Disjoint_Sets"
           "List-Index.List_Index"
           "../SAT_To_XC/XC_Definition" 
           Three_DM_Definition
-          "../../Lib/Auxiliaries/discriminated_Union"
-          "../../Lib/Auxiliaries/Set_Auxiliaries" (* card_Collect_mem *)
-        
+          "Poly_Reductions_Lib.Discriminated_Union"        
 begin
 
 section \<open>Helper lemmas\<close>

--- a/Karp21/XC_To_3DM/Three_DM_Definition.thy
+++ b/Karp21/XC_To_3DM/Three_DM_Definition.thy
@@ -1,5 +1,5 @@
 theory Three_DM_Definition
-  imports "HOL-Library.Disjoint_Sets"  "../Reductions"  "../../Lib/Auxiliaries/Set_Auxiliaries"
+  imports "HOL-Library.Disjoint_Sets" "../Reductions" "Poly_Reductions_Lib.Set_Auxiliaries"
 begin
 
 section \<open>Triplets with distinct components\<close>

--- a/Lib/Auxiliaries/discriminated_Union.thy
+++ b/Lib/Auxiliaries/discriminated_Union.thy
@@ -1,4 +1,4 @@
-theory discriminated_Union
+theory Discriminated_Union
   imports "HOL-Library.Disjoint_Sets" 
           Automatic_Refinement.Misc (* for img_fst [intro] which proves fst_discr_Un *)
 begin           

--- a/Lib/ROOT
+++ b/Lib/ROOT
@@ -1,0 +1,25 @@
+session Poly_Reductions_Lib = "HOL-Analysis" +
+  sessions
+    "HOL-Eisbach"
+    "HOL-ex"
+    "HOL-Real_Asymp"
+    Akra_Bazzi
+    Automatic_Refinement
+    DigitsInBase
+    Landau_Symbols
+    Graph_Theory
+    Tree_Enumeration
+  directories
+    Auxiliaries
+    Graph_Extensions
+  theories
+    Graph_Auxiliaries
+    Landau_Auxiliaries
+    List_Auxiliaries
+    Set_Auxiliaries
+    Discriminated_Union
+    Vwalk_Cycle
+    Discrete_Extensions
+    Polynomial_Growth_Functions
+    SAT_Definition
+    Triangle_Extensions


### PR DESCRIPTION
I added an overview of the reductions in the file `All_Reductions.thy`. It encodes the dependency graph of the reductions by nesting the list correspondingly. @alasleimi should complete the list by filling in the theorems. Additionally, we need an overview of the reductions where polynomial bounds were proved.

I also did a bit of refactoring. This includes the addition of two ROOT files which allow you to open the reduction theories with `isabelle jedit -d Karp21 -d Lib -d PATH_OF_NREST`, i.e. you don't need isabelle-dev nor `Transport` nor `ML_Typeclasses`.